### PR TITLE
Bvrda indexed markers

### DIFF
--- a/Matlab/xdf/load_xdf.m
+++ b/Matlab/xdf/load_xdf.m
@@ -610,8 +610,7 @@ if ~any(strcmp('all',opts.DisableVendorSpecifics))
                         end
                     end
                 end
-                streams{ k }.time_series( mkChan, : ) = []; % Remove marker index channel
-                streams{ k }.info.desc.channels.channel( mkChan ) = [];
+
             end
 
         end
@@ -1053,5 +1052,12 @@ end
 % Remove markers without corresponding marker channel sample
 streams{ mkStream }.time_stamps( clearMarkers ) = [];
 streams{ mkStream }.time_series( clearMarkers ) = [];
+
+% Remove marker index channel
+streams{ dataStream }.time_series( mkChan, : ) = []; 
+streams{ dataStream }.info.desc.channels.channel( mkChan ) = [];
+
+% Decrement channal count by 1
+streams{ dataStream }.info.channel_count = num2str( str2num( streams{ dataStream }.info.channel_count ) - 1 );
 
 end

--- a/Matlab/xdf/load_xdf.m
+++ b/Matlab/xdf/load_xdf.m
@@ -609,8 +609,16 @@ if ~any(strcmp('all',opts.DisableVendorSpecifics))
                             streams = ProcessBVRDAindexedMarkers( streams, k, m, mkChan );
                         end
                     end
+					
+					% Remove marker index channel
+					streams{ k }.time_series( mkChan, : ) = []; 
+					streams{ k }.info.desc.channels.channel( mkChan ) = [];
+					
+					% Decrement channel count by 1
+					streams{ k }.info.channel_count = num2str( str2num( streams{ k }.info.channel_count ) - 1 );
+					
                 end
-
+				
             end
 
         end
@@ -1053,11 +1061,5 @@ end
 streams{ mkStream }.time_stamps( clearMarkers ) = [];
 streams{ mkStream }.time_series( clearMarkers ) = [];
 
-% Remove marker index channel
-streams{ dataStream }.time_series( mkChan, : ) = []; 
-streams{ dataStream }.info.desc.channels.channel( mkChan ) = [];
-
-% Decrement channal count by 1
-streams{ dataStream }.info.channel_count = num2str( str2num( streams{ dataStream }.info.channel_count ) - 1 );
 
 end


### PR DESCRIPTION
This is the import part of the solution to the out-of-sync BrainVision RDA markers: the time stamps of a marker identifier channel in the EEG data are copied onto the corresponding markers. The identifier channel gets removed afterwards. This is done via a newly introduced vendor specific code section in the Matlab Importer. This behavior can be switched off per vendor or in total.