### PR TITLE
Fixed bugs in _jitter_removal

### DIFF
--- a/Python/xdf.py
+++ b/Python/xdf.py
@@ -538,10 +538,10 @@ def _jitter_removal(streams,
                     X = np.reshape(np.hstack((e, indices)), (2, -1)).T
                     y = stream.time_stamps[indices]
                     mapping = np.linalg.lstsq(X, y)[0]
-                    stream.time_stamps = mapping[0] + mapping[1]*indices
-                    effective_srate = np.array(effective_srate)
-                    num_samples = np.array(num_samples)
-                    x = np.sum(effective_srate/num_samples/np.sum(num_samples))
+                    stream.time_stamps[indices] = mapping[0] + mapping[1]*indices
+                    effective_srate_np = np.array(effective_srate)
+                    num_samples_np = np.array(num_samples)
+                    x = np.sum(effective_srate_np/num_samples_np/np.sum(num_samples_np))
                     stream.effective_srate = x
         else:
             stream.effective_srate = 0


### PR DESCRIPTION
Fixed two bugs:  
1. - At lines `542-543`: `list` type is converted to `nparray`;  
on next loop iteration the call to `list.append` fails.  
-- Fixed by storing converted arrays in temporary variables
2. * At line `541`: the entirety of `stream.time_stamps` is replaced with the current segment;  
on next loop iteration an array-out-of-bounds error occurs.  
-- Fixed by specifying the segment to replace - `stream.time_stamps[indices]`