### PR TITLE
Implement sync_timestamps

### DIFF
--- a/Python/pyxdf/pyxdf.py
+++ b/Python/pyxdf/pyxdf.py
@@ -12,7 +12,6 @@ import gzip
 import xml.etree.ElementTree as ET
 from collections import OrderedDict, defaultdict
 import logging
-from scipy.interpolate import interp1d
 import numpy as np
 
 __all__ = ['load_xdf']
@@ -59,13 +58,14 @@ def load_xdf(filename,
 
         sync_timestamps: {bool str}
             sync timestamps of all streams sample-wise with the stream to the 
-            highest effective sampling rate
+            highest effective sampling rate. Using sync_timestamps method has
+            a dependency on scipy, which is not a hard requirement of pyxdf.
             
             False -> no syncing
             True -> linear syncing
             str:<'linear’, ‘nearest’, ‘zero’, ‘slinear’, ‘quadratic’, ‘cubic’, 
             ‘previous’, ‘next’> for method inherited from  
-            scipy.interpolate.interp1d          
+            scipy.interpolate.interp1d.  
         
         overlap_timestamps: bool
             If true, return only overlapping streams, i.e. all streams
@@ -608,7 +608,7 @@ def _sync_timestamps(streams, kind='linear'):
     timepoint. Any time-stamps without a marker get then assigned an empty
     marker, i.e. [''].    
     '''
-    
+    from scipy.interpolate import interp1d
     # selecting the stream with the highest effective sampling rate
     srate_key = 'effective_srate'        
     srates = [stream['info'][srate_key] for stream in streams.values()]

--- a/Python/pyxdf/pyxdf.py
+++ b/Python/pyxdf/pyxdf.py
@@ -688,12 +688,17 @@ def _limit_streams_to_overlap(streams):
             
     ts_first = max(ts_first)
     ts_last = min(ts_last)
-    
     for stream in streams.values():
-        a = np.where(stream['time_stamps']>=ts_first)[0]
-        b = np.where(stream['time_stamps']<=ts_last)[0]
+        # use np.around to prevent floating point hickups
+        around = np.around(stream['time_stamps'], 15)
+        a = np.where(around>=ts_first)[0]
+        b = np.where(around<=ts_last)[0]
         select = np.intersect1d(a,b)               
-        stream['time_stamps'] = stream['time_stamps'][select]     
+        if type(stream['time_stamps']) is list:
+            stream['time_stamps'] = [stream['time_stamps'][s] for s in select]
+        else:
+            stream['time_stamps'] = stream['time_stamps'][select]     
+        
         if type(stream['time_series']) is list:
             stream['time_series'] = [stream['time_series'][s] for s in select]
         else:

--- a/Python/pyxdf/pyxdf.py
+++ b/Python/pyxdf/pyxdf.py
@@ -58,8 +58,11 @@ def load_xdf(filename,
 
         sync_timestamps: {bool str}
             sync timestamps of all streams sample-wise with the stream to the 
-            highest effective sampling rate. Using sync_timestamps method has
-            a dependency on scipy, which is not a hard requirement of pyxdf.
+            highest effective sampling rate. Using sync_timestamps with any 
+            method other than linear has dependency on scipy, which is not a
+            hard requirement of pyxdf. If scipy is not installed in your 
+            environment, the method supports linear interpolation with
+            numpy.
             
             False -> no syncing
             True -> linear syncing

--- a/Python/pyxdf/test/test_limit_on_synced_stamps.py
+++ b/Python/pyxdf/test/test_limit_on_synced_stamps.py
@@ -1,0 +1,71 @@
+from pyxdf.pyxdf import _sync_timestamps, _limit_streams_to_overlap
+import numpy as np
+# %%
+def streams():
+    #generate mock-streams
+    class MockStream(dict):
+    
+        def __init__(self, timestamps, timeseries, effective_srate, channel_format):
+            self['time_series'] = timeseries
+            self['time_stamps'] = timestamps
+            self['info']        = {}
+            self['info']['effective_srate'] = effective_srate
+            self['info']['channel_format'] = channel_format
+            
+    streams = {}
+    # fastest stream, latest timestamp
+    streams[1] = MockStream(np.linspace(1,2,1001), 
+                            np.linspace(1,2,1001), 
+                            1000,  ['float32'])
+    
+    # slowest stream, earliest timestamp
+    streams[2] = MockStream(np.linspace(0.5,1.5,251), 
+                            np.linspace(.5, 1.5, 251), 
+                            250, ['float32'])
+      
+    # marker stream
+    streams[3] = MockStream([0.2, 1.1071, 1.2, 1.9, 2.5],
+                            ['mark_' + str(n) for n in range(0,5,1)], 
+                            0, ['string'])
+    # integer datatype stream, 
+    streams[4] = MockStream(np.linspace(0.4,1.4,251), 
+                            np.linspace(4, 140, 251, dtype='int32'), 
+                            250, ['int32'])
+
+    return streams
+    
+def mock():
+    synced = _sync_timestamps(streams())
+    return _limit_streams_to_overlap(synced)
+    
+#%% test
+# earliest overlapping timestamp is 1.0 from stream 1
+# latest overlapping timestamp is 1.4 from stream 4
+# fastest strteam is stream 1 with fs 1000
+def test_timestamps():
+    'check timestamps streams'
+    for s in mock().values():        
+        assert np.all(np.isclose(s['time_stamps'], np.linspace(1, 1.4, 401)))
+
+def test_first_timeseries():
+    assert np.all(np.isclose(mock()[1]['time_series'], 
+                             np.linspace(1, 1.4, 401)))
+    
+def test_second_timeseries():
+    assert np.all(np.isclose(mock()[2]['time_series'], 
+                             np.linspace(1, 1.4, 401)))
+    
+def test_third_timeseries():
+    s = mock()[3]['time_series']
+    idx = np.where(s!='')[0]
+    assert np.all(idx == [107, 200])    
+    assert mock()[3]['time_stamps'][idx[0]] == 1.107 # shifted to closest fit 
+    assert mock()[3]['time_stamps'][idx[1]] == 1.2 # fits with fs 1000
+    
+def test_fourth_timeseries():
+    # interpolation is tricky, as it depends on np.around and linear 
+    # interpolation, which can not be approximated with np.linspace
+    # we therefore only test first and last value of the series
+    s = mock()[4]['time_series']    
+    assert np.isclose(s[0], 85)
+    assert np.isclose(s[-1], 140)

--- a/Python/pyxdf/test/test_limit_streams_to_overlap.py
+++ b/Python/pyxdf/test/test_limit_streams_to_overlap.py
@@ -30,54 +30,24 @@ def streams():
     return streams
 
 # %% test
-    
-def test_earliest_marker_stamp():
-    'check validity of first element in marker stream'
-    olap = _limit_streams_to_overlap(streams())
-    assert np.isclose(olap[3]['time_stamps'][0], 1.1071)
-    
-def test_latest_marker_stamp():
-    'check validity of first element in marker stream'
-    olap = _limit_streams_to_overlap(streams())
-    assert np.isclose(olap[3]['time_stamps'][-1], 1.2)
 
-def test_earliest_marker_series():
+def test_timestamps():
+    'test whether the first and last timestamps have been selected as expected'
     olap = _limit_streams_to_overlap(streams())
-    assert olap[3]['time_series'][0] == 'mark_1'
+    for s,v in zip(olap.values(), 
+                   [(1, 1.4), (1, 1.4), (1.1071, 1.2)]):
+        assert np.isclose(s['time_stamps'][0], v[0])
+        assert np.isclose(s['time_stamps'][-1], v[-1])
     
-def test_latest_marker_series():
+def test_timeseries():
+    'test whether the first and last value are as expected'
     olap = _limit_streams_to_overlap(streams())
-    assert olap[3]['time_series'][-1] == 'mark_2' 
-    
-def test_earliest_fast_stamp():
-    olap = _limit_streams_to_overlap(streams())
-    assert np.isclose(olap[1]['time_stamps'][0], 1.) 
-    
-def test_earliest_fast_series():
-    olap = _limit_streams_to_overlap(streams())
-    assert np.isclose(olap[1]['time_stamps'][0], 1.) 
-    
-def test_latest_fast_stamp():
-    olap = _limit_streams_to_overlap(streams())
-    assert np.isclose(olap[1]['time_stamps'][-1], 1.4) 
-    
-def test_latest_fast_series():
-    olap = _limit_streams_to_overlap(streams())
-    assert np.isclose(olap[1]['time_stamps'][-1], 1.4) 
-    
-def test_earliest_slow_stamp():
-    olap = _limit_streams_to_overlap(streams())
-    assert np.isclose(olap[1]['time_stamps'][0], 1.) 
-    
-def test_earliest_slow_series():
-    olap = _limit_streams_to_overlap(streams())
-    assert np.isclose(olap[1]['time_stamps'][0], 1.) 
-    
-def test_latest_slow_stamp():
-    olap = _limit_streams_to_overlap(streams())
-    assert np.isclose(olap[1]['time_stamps'][-1], 1.4) 
-    
-def test_latest_slow_series():
-    olap = _limit_streams_to_overlap(streams())
-    assert np.isclose(olap[1]['time_stamps'][-1], 1.4) 
+    for s,v in zip(olap.values(), 
+                   [(1, 1.4), (1, 1.4), ('mark_1', 'mark_2')]):
+        if s['info']['channel_format'] != ['string']:
+            assert np.isclose(s['time_series'][0], v[0])
+            assert np.isclose(s['time_series'][-1], v[-1])
+        else:
+            assert s['time_series'][0] == v[0]
+            assert s['time_series'][-1] == v[-1]
     

--- a/Python/pyxdf/test/test_limit_streams_to_overlap.py
+++ b/Python/pyxdf/test/test_limit_streams_to_overlap.py
@@ -1,4 +1,83 @@
 from pyxdf.pyxdf import _limit_streams_to_overlap
+import numpy as np
+# %%
+def streams():
+    #generate mock-streams
+    class MockStream(dict):
+    
+        def __init__(self, timestamps, timeseries, effective_srate, channel_format):
+            self['time_series'] = timeseries
+            self['time_stamps'] = timestamps
+            self['info']        = {}
+            self['info']['effective_srate'] = effective_srate
+            self['info']['channel_format'] = channel_format
+            
+    streams = {}
+    # fastest stream, latest timestamp
+    streams[1] = MockStream(np.linspace(1,2,1001), 
+                            np.linspace(1,2,1001), 
+                            1000,  ['float32'])
+    
+    # slowest stream, earliest timestamp
+    streams[2] = MockStream(np.linspace(0.4,1.4,251), 
+                            np.linspace(0.4,1.4,251), 
+                            250, ['float32'])
+      
+    # marker stream
+    streams[3] = MockStream([0.2, 1.1071, 1.2, 1.9, 2.5],
+                            ['mark_' + str(n) for n in range(0,5,1)], 
+                            0, ['string'])
+    return streams
 
+# %% test
+    
+def test_earliest_marker_stamp():
+    'check validity of first element in marker stream'
+    olap = _limit_streams_to_overlap(streams())
+    assert np.isclose(olap[3]['time_stamps'][0], 1.1071)
+    
+def test_latest_marker_stamp():
+    'check validity of first element in marker stream'
+    olap = _limit_streams_to_overlap(streams())
+    assert np.isclose(olap[3]['time_stamps'][-1], 1.2)
 
-
+def test_earliest_marker_series():
+    olap = _limit_streams_to_overlap(streams())
+    assert olap[3]['time_series'][0] == 'mark_1'
+    
+def test_latest_marker_series():
+    olap = _limit_streams_to_overlap(streams())
+    assert olap[3]['time_series'][-1] == 'mark_2' 
+    
+def test_earliest_fast_stamp():
+    olap = _limit_streams_to_overlap(streams())
+    assert np.isclose(olap[1]['time_stamps'][0], 1.) 
+    
+def test_earliest_fast_series():
+    olap = _limit_streams_to_overlap(streams())
+    assert np.isclose(olap[1]['time_stamps'][0], 1.) 
+    
+def test_latest_fast_stamp():
+    olap = _limit_streams_to_overlap(streams())
+    assert np.isclose(olap[1]['time_stamps'][-1], 1.4) 
+    
+def test_latest_fast_series():
+    olap = _limit_streams_to_overlap(streams())
+    assert np.isclose(olap[1]['time_stamps'][-1], 1.4) 
+    
+def test_earliest_slow_stamp():
+    olap = _limit_streams_to_overlap(streams())
+    assert np.isclose(olap[1]['time_stamps'][0], 1.) 
+    
+def test_earliest_slow_series():
+    olap = _limit_streams_to_overlap(streams())
+    assert np.isclose(olap[1]['time_stamps'][0], 1.) 
+    
+def test_latest_slow_stamp():
+    olap = _limit_streams_to_overlap(streams())
+    assert np.isclose(olap[1]['time_stamps'][-1], 1.4) 
+    
+def test_latest_slow_series():
+    olap = _limit_streams_to_overlap(streams())
+    assert np.isclose(olap[1]['time_stamps'][-1], 1.4) 
+    

--- a/Python/pyxdf/test/test_limit_streams_to_overlap.py
+++ b/Python/pyxdf/test/test_limit_streams_to_overlap.py
@@ -1,0 +1,4 @@
+from pyxdf.pyxdf import _limit_streams_to_overlap
+
+
+

--- a/Python/pyxdf/test/test_sync_timestamps.py
+++ b/Python/pyxdf/test/test_sync_timestamps.py
@@ -43,6 +43,11 @@ def synced(streams):
     return synced
 
 #%% test
+def test_samplingrate(synced):
+    'check that for all streams the sampling rate is identical to the fastest'
+    for s in synced.values():                
+        assert(s['info']['effective_srate']==1000)    
+
 def test_earliest(synced):
     'should expand to the earliest timestamp, which is 0.1 from stream 2'
     for stream in synced.values():
@@ -88,3 +93,4 @@ def test_integer_interpolation(synced, streams):
     u = np.unique(synced[4]['time_series'])
     u = np.int64(np.compress(~np.isnan(u), u))
     assert np.all(streams[4]['time_series'] == u)
+    

--- a/Python/pyxdf/test/test_sync_timestamps.py
+++ b/Python/pyxdf/test/test_sync_timestamps.py
@@ -48,19 +48,15 @@ def test_samplingrate(synced):
     for s in synced.values():                
         assert(s['info']['effective_srate']==1000)    
 
-def test_earliest(synced):
-    'should expand to the earliest timestamp, which is 0.1 from stream 2'
-    for stream in synced.values():
-        assert np.isclose(stream['time_stamps'][0], 0.1)
-
-def test_lastest(synced):
-    'should expand to the latest timestamp, which is 2.5 from stream 3'
-    for stream in synced.values():
-        assert np.isclose(stream['time_stamps'][-1], 2.5)
+def test_timestamps(synced):
+    '''test whether all timestamps are identical and as expected
+    earliest timestamp is 0.1 from stream 1,4; latest is 2.5 from stream 3'''
+    for s in synced.values():
+        assert np.all(np.isclose(s['time_stamps'], np.linspace(.1, 2.5, 2401)))        
      
-def test_identical_steps(synced):
-    for stream in synced.values():
-        'all steos between samples should be identical within float precision'
+def test_identical_timestamp_steps(synced):
+    'all steps between samples should be identical within float precision'
+    for stream in synced.values():        
         uq = np.diff(stream['time_stamps'])
         assert np.all([np.isclose(u, uq) for u in uq])
 
@@ -72,16 +68,47 @@ def test_markerstream(synced, streams):
     for marker in streams[3]['time_series']:
         idx.append(synced[3]['time_series'].tolist().index([marker]))
     assert np.all(np.equal(synced[3]['time_stamps'][idx],
-                           np.array([0.2 , 1.107, 1.2  , 1.9  , 2.5  ])))
+                           np.array([0.2 , #identical
+                                     1.107, #shifted
+                                     1.2  , 1.9  , 2.5  ]#shifted
+                                    )))
 
 def test_interpolation(synced):
     '''the linearly to 1000 Hz interpolated data from stream 2 should 
-    be identical with a linspace with 1001 samples'''
+    be identical with a linspace with 1001 samples.'''
     idx = np.where(~np.isnan(synced[2]['time_series']))[0]
     assert np.all(np.isclose(synced[2]['time_series'][idx], 
                              np.linspace(2, 1, 1001)))
-                             
-                             
+    
+def test_extrapolation(synced, streams):
+    '''extrapolated data should be nans or "" for markers '''
+    # stream 1 is extrapolated from 0.1 up to 1 and after 2 to 2.5
+    idx = np.where(np.isnan(synced[1]['time_series']))[0]
+    values = synced[1]['time_stamps'][idx]    
+    expectation = np.hstack((np.linspace(.1, 1, 900, endpoint=False),
+                             np.linspace(2.001, 2.5, 500, endpoint=True)))
+    assert np.all(np.isclose(values, expectation))
+    
+    # stream 2 is extrapolated from after 1.1 to 2.5
+    idx = np.where(np.isnan(synced[2]['time_series']))[0]
+    values = synced[2]['time_stamps'][idx]    
+    expectation = np.linspace(1.101, 2.5, num=1400, endpoint=True)
+    assert np.all(np.isclose(values, expectation))
+    
+    # stream 3 is extrapolated everywhere but at the marker stamps
+    # can be tested easier by checking whether the count of [''] 
+    # equals the total samples minus the original markers
+    values = np.where(synced[3]['time_series']==[''])[0].shape[0]
+    expectation = (synced[3]['time_series'].shape[0] - 
+                   len(streams[3]['time_series']))
+    assert values == expectation
+    
+    # stream 4 is extrapolated from after 1.1 to 2.5
+    idx = np.where(np.isnan(synced[4]['time_series']))[0]
+    values = synced[4]['time_stamps'][idx]    
+    expectation = np.linspace(1.101, 2.5, num=1400, endpoint=True)
+    assert np.all(np.isclose(values, expectation))    
+                                            
 def test_identity_after_interpolation(synced, streams):
     'the data for stream 1 should be identical to original'
     idx = np.where(~np.isnan(synced[1]['time_series']))[0]
@@ -89,7 +116,12 @@ def test_identity_after_interpolation(synced, streams):
                              streams[1]['time_series']))
                              
 def test_integer_interpolation(synced, streams):
-    'the data of stream 4 should be all integers'
+    '''the data of stream 4 should be all integers. 
+    
+    .. note::
+        interpolation is tricky, as it depends on np.around and linear 
+        interpolation, which can not be approximated with np.linspace
+    '''
     u = np.unique(synced[4]['time_series'])
     u = np.int64(np.compress(~np.isnan(u), u))
     assert np.all(streams[4]['time_series'] == u)

--- a/Python/pyxdf/test/test_sync_timestamps.py
+++ b/Python/pyxdf/test/test_sync_timestamps.py
@@ -1,0 +1,78 @@
+from pyxdf.pyxdf import _sync_timestamps
+import numpy as np
+from copy import deepcopy
+import pytest
+# %%
+@pytest.fixture(scope='session')
+def streams():
+    #generate mock-streams
+    class MockStream(dict):
+    
+        def __init__(self, timestamps, timeseries, effective_srate, channel_format):
+            self['time_series'] = timeseries
+            self['time_stamps'] = timestamps
+            self['info']        = {}
+            self['info']['effective_srate'] = effective_srate
+            self['info']['channel_format'] = channel_format
+            
+    streams = {}
+    # fastest stream, latest timestamp
+    streams[1] = MockStream(np.linspace(1,2,1001), 
+                            np.linspace(1,2,1001), 
+                            1000,  ['float32'])
+    
+    # slowest stream, earliest timestamp
+    streams[2] = MockStream(np.linspace(0.1,1.1,251), 
+                            np.linspace(2,1,251), 
+                            250, ['float32'])
+      
+    # marker stream
+    streams[3] = MockStream([0.2, 1.1071, 1.2, 1.9, 2.5],
+                            ['mark_' + str(n) for n in range(0,5,1)], 
+                            0, ['string'])
+    return streams
+
+@pytest.fixture(scope='session')
+def synced(streams):
+    synced = _sync_timestamps(deepcopy(streams))
+    return synced
+
+#%% test
+def test_earliest(synced):
+    'should expand to the earliest timestamp, which is 0.1 from stream 2'
+    for stream in synced.values():
+        assert np.isclose(stream['time_stamps'][0], 0.1)
+
+def test_lastest(synced):
+    'should expand to the latest timestamp, which is 2.5 from stream 3'
+    for stream in synced.values():
+        assert np.isclose(stream['time_stamps'][-1], 2.5)
+     
+def test_identical_steps(synced):
+    for stream in synced.values():
+        'all steos between samples should be identical within float precision'
+        uq = np.diff(stream['time_stamps'])
+        assert np.all([np.isclose(u, uq) for u in uq])
+
+def test_markerstream(synced, streams):
+    '''check markers, they should be identical to the original but the second,
+       which should be shifted towards the next valid sample of the fastest 
+       stream'''
+    idx = []
+    for marker in streams[3]['time_series']:
+        idx.append(synced[3]['time_series'].tolist().index([marker]))
+    assert np.all(np.equal(synced[3]['time_stamps'][idx],
+                           np.array([0.2 , 1.107, 1.2  , 1.9  , 2.5  ])))
+
+def test_interpolation(synced):
+    '''the linearly to 1000 Hz interpolated data from stream 2 should 
+    be identical with a linspace with 1001 samples'''
+    idx = np.where(~np.isnan(synced[2]['time_series']))[0]
+    assert np.all(np.isclose(synced[2]['time_series'][idx], 
+                             np.linspace(2, 1, 1001)))
+
+def test_identity_after_interpolation(synced, streams):
+    'the data for stream 1 should be identical to original'
+    idx = np.where(~np.isnan(synced[1]['time_series']))[0]
+    assert np.all(np.isclose(synced[1]['time_series'][idx],
+                             streams[1]['time_series']))

--- a/Python/pyxdf/test/test_sync_timestamps.py
+++ b/Python/pyxdf/test/test_sync_timestamps.py
@@ -30,6 +30,11 @@ def streams():
     streams[3] = MockStream([0.2, 1.1071, 1.2, 1.9, 2.5],
                             ['mark_' + str(n) for n in range(0,5,1)], 
                             0, ['string'])
+    # integer datatype stream, 
+    streams[4] = MockStream(np.linspace(0.1,1.1,251), 
+                            np.linspace(0, 250, 251, dtype='int32'), 
+                            250, ['int32'])
+
     return streams
 
 @pytest.fixture(scope='session')
@@ -70,9 +75,16 @@ def test_interpolation(synced):
     idx = np.where(~np.isnan(synced[2]['time_series']))[0]
     assert np.all(np.isclose(synced[2]['time_series'][idx], 
                              np.linspace(2, 1, 1001)))
-
+                             
+                             
 def test_identity_after_interpolation(synced, streams):
     'the data for stream 1 should be identical to original'
     idx = np.where(~np.isnan(synced[1]['time_series']))[0]
     assert np.all(np.isclose(synced[1]['time_series'][idx],
                              streams[1]['time_series']))
+                             
+def test_integer_interpolation(synced, streams):
+    'the data of stream 4 should be all integers'
+    u = np.unique(synced[4]['time_series'])
+    u = np.int64(np.compress(~np.isnan(u), u))
+    assert np.all(streams[4]['time_series'] == u)


### PR DESCRIPTION
Allows to resample (using interpolation for numeric values and shifting for strings) all streams to have their timestamps sample-wise in sync with the fastest stream. 
Example 
```streams, fileheader = load_xdf(filename, sync_timestamps='linear')```
This might help adress https://github.com/sccn/xdf/issues/24  and https://github.com/mne-tools/mne-python/issues/5180