### PR TITLE
Do not sort streams

### DIFF
--- a/Python/pyxdf/pyxdf.py
+++ b/Python/pyxdf/pyxdf.py
@@ -373,8 +373,6 @@ def load_xdf(filename,
         stream['time_stamps'] = tmp.time_stamps
 
     streams = [s for s in streams.values()]
-    sort_data = [s['info']['name'][0] for s in streams]
-    streams = [x for _, x in sorted(zip(sort_data, streams))]
     return streams, fileheader
 
 


### PR DESCRIPTION
Fixes #35. Sorting streams by their names does not work in general because stream names don't have to be unique. As a simple fix I suggest to remove the sorting for now.