### PR TITLE
Adding submodule ref for xdf-tagger utility

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "Julia"]
     path = Julia
     url = https://github.com/cbrnr/XDF.jl.git
+[submodule "Utilities/xdf-tagger"]
+	path = Utilities/xdf-tagger
+	url = https://github.com/xdf-modules/xdf-tagger.git


### PR DESCRIPTION
Adding a path `Utilities/xdf-tagger` that references the recently-contributed `github.com/xdf-modules/xdf-tagger` repo. Later we can add other utilities under Utilities.